### PR TITLE
Added simplecov to gem file and at the top of spec files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'cane'
 gem 'reek'
 gem 'rake'
 gem 'rspec'
+gem 'simplecov', require: false, group: :test

--- a/test/item_repository_spec.rb
+++ b/test/item_repository_spec.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+SimpleCov.start
 require './lib/item_repository'
 
 RSpec.describe ItemRepository do

--- a/test/merchant_repository_spec.rb
+++ b/test/merchant_repository_spec.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+SimpleCov.start
 require './lib/merchant'
 require './lib/merchant_repository'
 

--- a/test/sales_analyst_spec.rb
+++ b/test/sales_analyst_spec.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+SimpleCov.start
 require './lib/sales_engine'
 require './lib/sales_analyst'
 

--- a/test/sales_engine_spec.rb
+++ b/test/sales_engine_spec.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+SimpleCov.start
 require './lib/merchant_repository'
 require './lib/merchant'
 require './lib/sales_engine'


### PR DESCRIPTION
This just adds simplecov to the gem file and requires it in each spec file. It still carries the piece that's broken in the merchant_repository.rb and is failing the test.